### PR TITLE
'make' command failed, missing ';'

### DIFF
--- a/tflmicro/examples/person_detection_screen/main_functions.cpp
+++ b/tflmicro/examples/person_detection_screen/main_functions.cpp
@@ -44,7 +44,7 @@ TfLiteTensor *            input          = nullptr;
 // signed value.
 
 // An area of memory to use for input, output, and intermediate arrays.
-constexpr int  kTensorArenaSize =  81 * 1024 // 136 * 1024;
+constexpr int  kTensorArenaSize =  81 * 1024; // 136 * 1024;
 static uint8_t tensor_arena[kTensorArenaSize];
 }  // namespace
 


### PR DESCRIPTION
Hello,

'make' command failed, missing ';' 

I tried to compile by:
1. git clone git@github.com:ArduCAM/RPI-Pico-Cam.git
2. cd RPI-Pico-Cam
3. cd tflmicro
4. mkdir build
5. cd build
6. cmake ..
7. make

The output:
`[ 88%] Building CXX object examples/person_detection_screen/CMakeFiles/person_detection_screen_int8.dir/main_functions.cpp.obj
<omitted>/RPI-Pico-Cam/tflmicro/examples/person_detection_screen/main_functions.cpp:48:1: error: expected ',' or ';' before 'static'
   48 | static uint8_t tensor_arena[kTensorArenaSize];
      | ^~~~~~
<omitted>/RPI-Pico-Cam/tflmicro/examples/person_detection_screen/main_functions.cpp: In function 'void setup()':
<omitted>/RPI-Pico-Cam/tflmicro/examples/person_detection_screen/main_functions.cpp:88:31: error: 'tensor_arena' was not declared in this scope
   88 |     model, micro_op_resolver, tensor_arena, kTensorArenaSize, error_reporter);
      |                               ^~~~~~~~~~~~
make[2]: *** [examples/person_detection_screen/CMakeFiles/person_detection_screen_int8.dir/build.make:102: examples/person_detection_screen/CMakeFiles/person_detection_screen_int8.dir/main_functions.cpp.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:2019: examples/person_detection_screen/CMakeFiles/person_detection_screen_int8.dir/all] Error 2
`

After adding ';', build is successful.
